### PR TITLE
Refactor serializers and add GameStateManager to Korge-fleks

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -10,7 +10,7 @@ on:
     branches: [ main ]
 
 env:
-  JAVA_VERSION: 17
+  JAVA_VERSION: 21
   JAVA_DISTRIBUTION: zulu
 
 jobs:
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up JDK
+    - name: Set up JDK 21
       uses: actions/setup-java@v3
       with:
           distribution: "${{ env.JAVA_DISTRIBUTION }}"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,3 +1,3 @@
 [plugins]
-korge = { id = "com.soywiz.korge", version = "5.4.0" }
+korge = { id = "com.soywiz.korge", version = "6.0.0-beta4" }
 #korge = { id = "com.soywiz.korge", version = "999.0.0.999" }

--- a/korge-fleks/kproject.yml
+++ b/korge-fleks/kproject.yml
@@ -11,6 +11,7 @@ dependencies:
 #
 #  - ../../fleks
 #
+  - maven::common::com.charleskorn.kaml:kaml:0.61.0  # 0.59.0 <-- last version supporting kotlin 1.9.x and serialization 1.6.x
   - maven::common::com.soywiz.korlibs.korge2:korge
   - https://github.com/korlibs/korge-ldtk/tree/v1.0.3/korge-ldtk
   # Use local copy of KorGE addons

--- a/korge-fleks/src/commonMain/kotlin/korlibs/korge/fleks/entity/EntityFactory.kt
+++ b/korge-fleks/src/commonMain/kotlin/korlibs/korge/fleks/entity/EntityFactory.kt
@@ -3,7 +3,6 @@ package korlibs.korge.fleks.entity
 import com.github.quillraven.fleks.Entity
 import com.github.quillraven.fleks.World
 import korlibs.korge.fleks.components.*
-import korlibs.korge.fleks.entity.EntityFactory.EntityConfig
 import korlibs.korge.fleks.utils.*
 
 
@@ -19,24 +18,6 @@ import korlibs.korge.fleks.utils.*
  * [EntityConfig].
  */
 object EntityFactory {
-
-    /**
-     * This interface maps the string [name] to a specific game object configuration process.
-     * The game object entity will be created by the [entityConfigure] function which can be configured through additional
-     * config properties in the derived class.
-     *
-     * Hint:
-     * Deriving the configuration for an entity from this interface keeps the configuration details (config properties)
-     * together with the creation/configuration process of a complex game object which can consist of multiple entities.
-     * Also, the creation process of the game object can involve multiple steps of [entityConfigure] calls. Thus,
-     * it is possible to use a "layered" creation process for entities where each layer adds global, common or more
-     * specific components or sub-entities to a game object.
-     */
-    interface EntityConfig {
-        val name: String
-        fun World.entityConfigure(entity: Entity) : Entity
-    }
-
     // Internal storage for entity config objects
     private val entityConfigs: MutableMap<String, EntityConfig> = mutableMapOf()
 
@@ -48,6 +29,11 @@ object EntityFactory {
     fun register(entityConfig: EntityConfig) {
         entityConfigs[entityConfig.name] = entityConfig
     }
+
+    /**
+     * This function checks if an [EntityConfig] with a specific [name] is already registered in the factory.
+     */
+    fun contains(name: String) = entityConfigs.containsKey(name)
 
     /**
      * Configure (after optional creation of a new entity) an entity with a specific [EntityConfig] by calling the

--- a/korge-fleks/src/commonMain/kotlin/korlibs/korge/fleks/entity/config/DialogBoxConfig.kt
+++ b/korge-fleks/src/commonMain/kotlin/korlibs/korge/fleks/entity/config/DialogBoxConfig.kt
@@ -5,7 +5,6 @@ import korlibs.image.text.*
 import korlibs.korge.fleks.components.*
 import korlibs.korge.fleks.components.TweenSequenceComponent.*
 import korlibs.korge.fleks.entity.*
-import korlibs.korge.fleks.entity.EntityFactory.EntityConfig
 import korlibs.korge.fleks.tags.*
 import korlibs.korge.fleks.utils.*
 import korlibs.math.geom.*

--- a/korge-fleks/src/commonMain/kotlin/korlibs/korge/fleks/entity/config/FireAndDustEffectConfig.kt
+++ b/korge-fleks/src/commonMain/kotlin/korlibs/korge/fleks/entity/config/FireAndDustEffectConfig.kt
@@ -6,9 +6,8 @@ import korlibs.image.format.*
 import korlibs.korge.fleks.components.*
 import korlibs.korge.fleks.components.TweenSequenceComponent.*
 import korlibs.korge.fleks.entity.*
-import korlibs.korge.fleks.entity.EntityFactory.EntityConfig
 import korlibs.korge.fleks.tags.*
-import korlibs.korge.fleks.utils.random
+import korlibs.korge.fleks.utils.*
 import kotlinx.serialization.*
 
 

--- a/korge-fleks/src/commonMain/kotlin/korlibs/korge/fleks/entity/config/LevelMapConfig.kt
+++ b/korge-fleks/src/commonMain/kotlin/korlibs/korge/fleks/entity/config/LevelMapConfig.kt
@@ -5,8 +5,8 @@ import com.github.quillraven.fleks.World
 import korlibs.korge.fleks.assets.*
 import korlibs.korge.fleks.components.*
 import korlibs.korge.fleks.entity.*
-import korlibs.korge.fleks.entity.EntityFactory.EntityConfig
 import korlibs.korge.fleks.tags.*
+import korlibs.korge.fleks.utils.*
 import kotlinx.serialization.*
 
 

--- a/korge-fleks/src/commonMain/kotlin/korlibs/korge/fleks/entity/config/LogoEntityConfig.kt
+++ b/korge-fleks/src/commonMain/kotlin/korlibs/korge/fleks/entity/config/LogoEntityConfig.kt
@@ -5,6 +5,7 @@ import korlibs.korge.fleks.assets.*
 import korlibs.korge.fleks.components.*
 import korlibs.korge.fleks.entity.*
 import korlibs.korge.fleks.tags.*
+import korlibs.korge.fleks.utils.*
 import kotlinx.serialization.*
 
 
@@ -31,7 +32,7 @@ data class LogoEntityConfig(
     private val layerIndex: Int,
     private val layerTag: RenderLayerTag
 
-) : EntityFactory.EntityConfig {
+) : EntityConfig {
 
     override fun World.entityConfigure(entity: Entity) : Entity {
         val assetStore: AssetStore = inject(name = "AssetStore")

--- a/korge-fleks/src/commonMain/kotlin/korlibs/korge/fleks/entity/config/MovedSpawnerObjectConfig.kt
+++ b/korge-fleks/src/commonMain/kotlin/korlibs/korge/fleks/entity/config/MovedSpawnerObjectConfig.kt
@@ -3,9 +3,8 @@ package korlibs.korge.fleks.entity.config
 import com.github.quillraven.fleks.Entity
 import com.github.quillraven.fleks.World
 import korlibs.korge.fleks.components.*
-import korlibs.korge.fleks.utils.random
 import korlibs.korge.fleks.entity.*
-import korlibs.korge.fleks.entity.EntityFactory.EntityConfig
+import korlibs.korge.fleks.utils.*
 import kotlinx.serialization.*
 
 

--- a/korge-fleks/src/commonMain/kotlin/korlibs/korge/fleks/entity/config/ParallaxEffectConfig.kt
+++ b/korge-fleks/src/commonMain/kotlin/korlibs/korge/fleks/entity/config/ParallaxEffectConfig.kt
@@ -6,7 +6,7 @@ import com.github.quillraven.fleks.World
 import korlibs.korge.fleks.components.*
 import korlibs.korge.fleks.tags.*
 import korlibs.korge.fleks.entity.*
-import korlibs.korge.fleks.entity.EntityFactory.EntityConfig
+import korlibs.korge.fleks.utils.*
 import kotlinx.serialization.*
 
 

--- a/korge-fleks/src/commonMain/kotlin/korlibs/korge/fleks/entity/config/RichTextConfig.kt
+++ b/korge-fleks/src/commonMain/kotlin/korlibs/korge/fleks/entity/config/RichTextConfig.kt
@@ -4,7 +4,6 @@ import com.github.quillraven.fleks.*
 import korlibs.image.text.*
 import korlibs.korge.fleks.components.*
 import korlibs.korge.fleks.entity.*
-import korlibs.korge.fleks.entity.EntityFactory.EntityConfig
 import korlibs.korge.fleks.tags.*
 import korlibs.korge.fleks.utils.*
 import kotlinx.serialization.*

--- a/korge-fleks/src/commonMain/kotlin/korlibs/korge/fleks/gameState/GameStateConfig.kt
+++ b/korge-fleks/src/commonMain/kotlin/korlibs/korge/fleks/gameState/GameStateConfig.kt
@@ -1,0 +1,14 @@
+package korlibs.korge.fleks.gameState
+
+import kotlinx.serialization.*
+
+
+@Serializable @SerialName("GameStateConfig")
+data class GameStateConfig(
+    // Name of game
+    val name: String,
+    var firstStart: Boolean,
+    var world: String,
+    var level: String,
+    var special: String
+)

--- a/korge-fleks/src/commonMain/kotlin/korlibs/korge/fleks/gameState/GameStateManager.kt
+++ b/korge-fleks/src/commonMain/kotlin/korlibs/korge/fleks/gameState/GameStateManager.kt
@@ -1,0 +1,185 @@
+package korlibs.korge.fleks.gameState
+
+import com.github.quillraven.fleks.World
+import korlibs.io.file.std.*
+import korlibs.korge.fleks.assets.*
+import korlibs.korge.fleks.entity.EntityFactory
+import korlibs.korge.fleks.utils.*
+import korlibs.korge.ldtk.*
+import kotlinx.serialization.*
+import kotlinx.serialization.modules.*
+
+/**
+ * The game state manager is responsible for loading and managing the game state.
+ * It loads the game config file 'game_config.yaml' and the common config file 'common/config.yaml' at the start of the game.
+ */
+object GameStateManager {
+    var assetStore: AssetStore = AssetStore()
+    var firstGameStart: Boolean = true
+
+    private lateinit var gameStateConfig: GameStateConfig
+    private val gameStateSerializer = EntityConfigSerializer()
+
+    /**
+     * Register a new serializers module for the entity config serializer.
+     */
+    fun register(name: String, module: SerializersModule) {
+        gameStateSerializer.register(name, module)
+    }
+
+    /**
+     * Init function for loading common game config and assets. Call this before any KorGE Scene is active.
+     */
+    suspend fun initGameState() {
+        // Check for game config file
+        val gameStateConfigVfs = resourcesVfs["game_config.yaml"]
+
+//        if (gameStateConfigVfs.exists()) {
+            // TODO Check why exits() function does not work on Android
+
+            val gameStateConfigString = gameStateConfigVfs.readString()
+            try {
+                gameStateConfig = gameStateSerializer.yaml().decodeFromString<GameStateConfig>(gameStateConfigString)
+            } catch (e: Throwable) {
+                gameStateConfig = GameStateConfig("", true, "", "", "")
+                println("ERROR: Loading game state config - $e")
+            }
+//        } else {
+//            gameStateConfig = GameStateConfig("", true, "", "", "")
+//            println("ERROR: Cannot find game state config file 'game_config.yaml'!")
+//        }
+        firstGameStart = gameStateConfig.firstStart
+
+        val vfs = resourcesVfs["common/config.yaml"]
+//        if (vfs.exists()) {
+            // TODO Check why exits() function does not work on Android
+
+            val gameConfigString = vfs.readString()
+            try {
+                val commonConfig = gameStateSerializer.yaml().decodeFromString<AssetModel>(gameConfigString)
+                // Enable / disable hot reloading of common assets here
+                assetStore.loadAssets(AssetType.COMMON, assetConfig = commonConfig)
+            } catch (e: Throwable) { println("ERROR: Loading common assets - $e") }
+//        } else println("WARNING: Cannot find common entity config file 'common/config.yaml'!")
+    }
+
+    /**
+     * Load all entity configs from LDtk level and put them into the EntityFactory.
+     */
+    private fun loadEntityConfigsFromLdtkLevel(worldName: String, levelName: String) {
+        var gameObjectCnt = 0
+
+        val gridSize = assetStore.getLdtkWorld(worldName).ldtk.defaultGridSize
+        val entityLayer = assetStore.getLdtkLevel(assetStore.getLdtkWorld(worldName), levelName).layerInstances?.firstOrNull { it.entityInstances.isNotEmpty() }
+        entityLayer?.entityInstances?.forEach { entity ->
+            println("INFO: Game object '${entity.identifier}' loaded for '$levelName'")
+
+            // Create YAML string of an entity config from LDtk
+            val yamlString = StringBuilder()
+            // Sanity check - entity needs to have a field 'entityConfig'
+            if (entity.fieldInstances.firstOrNull { it.identifier == "entityConfig" } != null) {
+
+                yamlString.append("-   name: ${worldName}_${levelName}_${entity.identifier}_${gameObjectCnt++}\n")
+
+                // Add position of entity
+                entity.tags.firstOrNull { it == "positionable" }?.let {
+                    yamlString.append("    x: ${entity.gridPos.x * gridSize}\n")
+                    yamlString.append("    y: ${entity.gridPos.y * gridSize}\n")
+                }
+
+                // Add all other fields of entity
+                entity.fieldInstances.forEach { field ->
+                    if (field.identifier != "EntityConfig") yamlString.append("    ${field.identifier}: ${field.value}\n")
+                }
+                println(yamlString)
+
+            } else println("ERROR: Game object with name '${entity.identifier}' has no field entityConfig")
+
+            try {
+                val entityConfigs: List<EntityConfig> =
+                    gameStateSerializer.yaml().decodeFromString(yamlString.toString())
+                entityConfigs.forEach { entityConfig ->
+                    EntityFactory.register(entityConfig)
+                }
+                println("INFO: Entity config '${entity.identifier}' loaded for '$levelName'")
+            } catch (e: Throwable) {
+                println("ERROR: Loading entity config - $e")
+            }
+        }
+    }
+
+    /**
+     * Function for loading word, level and special game config and assets. This function should be called
+     * whenever new assets need to be loaded. I.e. also within a level when assets of type 'special' should
+     * be loaded/reloaded.
+     */
+    suspend fun loadAssets() {
+        // Sanity check - world needs to be always present
+        if (gameStateConfig.world.isEmpty() || gameStateConfig.level.isEmpty()) {
+            println("ERROR: World or level string is empty in game config! Cannot load game data!")
+            return
+        }
+
+        // Start loading world assets
+        val worldVfs = resourcesVfs[gameStateConfig.world + "/config.yaml"]
+//        if (worldVfs.exists()) {
+            // TODO Check why exits() function does not work on Android
+
+            var gameConfigString = worldVfs.readString()
+            try {
+                val worldConfig = gameStateSerializer.yaml().decodeFromString<AssetModel>(gameConfigString)
+                // Enable / disable hot reloading of common assets here
+                assetStore.loadAssets(AssetType.WORLD, assetConfig = worldConfig)
+            } catch (e: Throwable) {
+                println("ERROR: Loading world assets - $e")
+            }
+//        } else println("WARNING: Cannot find world game config file '${gameStateConfig.world}/config.yaml'!")
+
+        // Start loading level assets
+        val levelVfs = resourcesVfs[gameStateConfig.world + "/" + gameStateConfig.level + "/config.yaml"]
+//        if (levelVfs.exists()) {
+            gameConfigString = levelVfs.readString()
+            try {
+                val worldConfig = gameStateSerializer.yaml().decodeFromString<AssetModel>(gameConfigString)
+                // Enable / disable hot reloading of common assets here
+                assetStore.loadAssets(AssetType.LEVEL, assetConfig = worldConfig)
+            } catch (e: Throwable) {
+                println("ERROR: Loading level assets - $e")
+            }
+//        } else println("WARNING: Cannot find level game config file '${gameStateConfig.world}/${gameStateConfig.level}/config.yaml'!")
+
+        // Start loading special assets
+        if (gameStateConfig.level.isNotEmpty()) {
+            val vfs = resourcesVfs[gameStateConfig.world + "/" + gameStateConfig.level + "/" + gameStateConfig.special + "/config.yaml"]
+//            if (vfs.exists()) {
+                gameConfigString = vfs.readString()
+                try {
+                    val specialConfig = gameStateSerializer.yaml().decodeFromString<AssetModel>(gameConfigString)
+                    // Enable / disable hot reloading of common assets here
+                    assetStore.loadAssets(AssetType.SPECIAL, assetConfig = specialConfig)
+                } catch (e: Throwable) {
+                    println("ERROR: Loading special assets - $e")
+                }
+//            } else println("WARNING: Cannot find special game config file '${gameStateConfig.special}/${gameStateConfig.special}/config.yaml'!")
+        }
+
+        loadEntityConfigsFromLdtkLevel(gameStateConfig.world, gameStateConfig.special)  // here entity configs for "intro" are loaded
+        loadEntityConfigsFromLdtkLevel(gameStateConfig.world, gameStateConfig.level)
+    }
+
+    /**
+     * This function is called to start the game. It will load the start script from the current LDtk level and
+     * create and configure the very first entity of the game.
+     */
+    fun startGame(world: World) {
+
+        val startScript = if (gameStateConfig.firstStart) "world_1_intro_start_script_0"
+            else "{${gameStateConfig.world}_${gameStateConfig.level}_start_script_0"
+
+        if (EntityFactory.contains(startScript)) {
+            println("INFO: Starting '${gameStateConfig.level}' with start script '$startScript'.")
+            world.createAndConfigureEntity(startScript)
+        }
+        else println("Error: Cannot start '${gameStateConfig.level}'! EntityConfig with name '$startScript' does not exist!")
+    }
+}

--- a/korge-fleks/src/commonMain/kotlin/korlibs/korge/fleks/gameState/GameStateManager.kt
+++ b/korge-fleks/src/commonMain/kotlin/korlibs/korge/fleks/gameState/GameStateManager.kt
@@ -79,7 +79,10 @@ object GameStateManager {
             // Sanity check - entity needs to have a field 'entityConfig'
             if (entity.fieldInstances.firstOrNull { it.identifier == "entityConfig" } != null) {
 
-                yamlString.append("-   name: ${worldName}_${levelName}_${entity.identifier}_${gameObjectCnt++}\n")
+                // Add scripts with their original name
+                if (entity.tags.firstOrNull { it == "script" } != null) yamlString.append("-   name: ${entity.identifier}\n")
+                // Add other game objects with an unique name as identifier
+                else yamlString.append("-   name: ${worldName}_${levelName}_${entity.identifier}_${gameObjectCnt++}\n")
 
                 // Add position of entity
                 entity.tags.firstOrNull { it == "positionable" }?.let {
@@ -170,14 +173,14 @@ object GameStateManager {
     /**
      * This function is called to start the game. It will load the start script from the current LDtk level and
      * create and configure the very first entity of the game.
+     *
+     * Hint: Make sure that a game object with name "start_script" is present in each LDtk level. It can be of dirrerent
+     * EntityConfig type. The type can be set in LDtk level map editor.
      */
     fun startGame(world: World) {
-
-        val startScript = if (gameStateConfig.firstStart) "world_1_intro_start_script_0"
-            else "{${gameStateConfig.world}_${gameStateConfig.level}_start_script_0"
-
+        val startScript = "start_script"
         if (EntityFactory.contains(startScript)) {
-            println("INFO: Starting '${gameStateConfig.level}' with start script '$startScript'.")
+            println("INFO: Starting '${gameStateConfig.level}' with script: '$startScript'.")
             world.createAndConfigureEntity(startScript)
         }
         else println("Error: Cannot start '${gameStateConfig.level}'! EntityConfig with name '$startScript' does not exist!")

--- a/korge-fleks/src/commonMain/kotlin/korlibs/korge/fleks/systems/SnapshotSerializerSystem.kt
+++ b/korge-fleks/src/commonMain/kotlin/korlibs/korge/fleks/systems/SnapshotSerializerSystem.kt
@@ -23,7 +23,7 @@ class SnapshotSerializerSystem(module: SerializersModule) : IntervalSystem(
 
     private val family: Family = world.family { all(ParallaxComponent) }
     private val snapshotSerializer = SnapshotSerializer().apply { register("module", module) }
-    private val recording: MutableList<Map<Entity, Snapshot>> = mutableListOf()  // mutableListWithCapacityOf(100000)
+    private val recording: MutableList<Map<Entity, Snapshot>> = mutableListOf()
     private var rewindSeek: Int = 0
     private var gameRunning: Boolean = true
 

--- a/korge-fleks/src/commonMain/kotlin/korlibs/korge/fleks/utils/EntityConfigSerializer.kt
+++ b/korge-fleks/src/commonMain/kotlin/korlibs/korge/fleks/utils/EntityConfigSerializer.kt
@@ -1,0 +1,80 @@
+package korlibs.korge.fleks.utils
+
+import com.charleskorn.kaml.*
+import com.github.quillraven.fleks.*
+import korlibs.korge.fleks.entity.config.*
+import kotlinx.serialization.modules.*
+
+
+/**
+ * This interface maps the string [name] to a specific game object configuration process.
+ * The game object entity will be created by the [entityConfigure] function which can be configured through additional
+ * config properties in the derived class.
+ *
+ * Hint:
+ * Deriving the configuration for an entity from this interface keeps the configuration details (config properties)
+ * together with the creation/configuration process of a complex game object which can consist of multiple entities.
+ * Also, the creation process of the game object can involve multiple steps of [entityConfigure] calls. Thus,
+ * it is possible to use a "layered" creation process for entities where each layer adds global, common or more
+ * specific components or sub-entities to a game object.
+ */
+interface EntityConfig {
+    val name: String
+    fun World.entityConfigure(entity: Entity) : Entity
+}
+
+class EntityConfigSerializer {
+    private val modulesMap = mutableMapOf<String, SerializersModule>()
+    private lateinit var yaml: Yaml
+    private var dirty = true
+
+    fun register(name: String, module: SerializersModule) {
+        modulesMap[name] = module
+        dirty = true
+    }
+
+    fun unregister(name: String) {
+        modulesMap.remove(name)
+    }
+
+    /**
+     * Get the Yaml serializer with all registered modules for deserializing entity configs from LDtk levels.
+     */
+    fun yaml() : Yaml {
+        if (dirty) {
+            var modules = internalModule
+            modulesMap.values.forEach { module ->
+                modules = modules.plus(module)
+            }
+            yaml = Yaml(
+                serializersModule = modules,
+                configuration = YamlConfiguration(
+                    encodingIndentationSize = 4,
+                    singleLineStringStyle = SingleLineStringStyle.DoubleQuoted,
+                    multiLineStringStyle = MultiLineStringStyle.DoubleQuoted,
+                    allowAnchorsAndAliases = true,
+                    polymorphismStyle = PolymorphismStyle.Property,
+                    polymorphismPropertyName = "entityConfig"
+                )
+            )
+            dirty = false
+        }
+        return yaml
+    }
+
+    /**
+     * This polymorphic module config for kotlinx serialization lists all Korge-fleks
+     * internal components as subclasses.
+     */
+    private val internalModule = SerializersModule {
+        // Register common entity config classes
+        polymorphic(EntityConfig::class) {
+            subclass(DialogBoxConfig::class)
+            subclass(RichTextConfig::class)
+            subclass(ParallaxEffectConfig::class)
+            subclass(LogoEntityConfig::class)
+            subclass(LevelMapConfig::class)
+            subclass(MovedSpawnerObjectConfig::class)
+        }
+    }
+}

--- a/korge-fleks/src/commonMain/kotlin/korlibs/korge/fleks/utils/SnapshotSerializer.kt
+++ b/korge-fleks/src/commonMain/kotlin/korlibs/korge/fleks/utils/SnapshotSerializer.kt
@@ -54,76 +54,6 @@ abstract class CloneableComponent<T> : Component<T> {
 value class Identifier(val name: String)
 
 /**
- * This polymorphic module config for kotlinx serialization lists all Korge-fleks
- * internal components as subclasses.
- */
-internal val internalModule = SerializersModule {
-    // Register data classes
-    polymorphic(CloneableData::class) {
-        subclass(ParallaxComponent.Layer::class)
-        subclass(ParallaxComponent.Plane::class)
-        subclass(RgbaComponent.Rgb::class)
-        subclass(OffsetByFrameIndexComponent.Point::class)
-        subclass(SpriteLayersComponent.LayerProperties::class)
-        subclass(LayeredSpriteComponent.Layer::class)
-    }
-
-    // Register component classes
-    polymorphic(Component::class) {
-        subclass(EntityLinkComponent::class)
-        subclass(InfoComponent::class)
-        subclass(TouchInputComponent::class)
-        subclass(LayerComponent::class)
-        subclass(LayeredSpriteComponent::class)
-        subclass(LayoutComponent::class)
-        subclass(LdtkLevelMapComponent::class)
-        subclass(LifeCycleComponent::class)
-        subclass(MotionComponent::class)
-        subclass(NoisyMoveComponent::class)
-        subclass(OffsetByFrameIndexComponent::class)
-        subclass(ParallaxComponent::class)
-        subclass(PositionComponent::class)
-        subclass(RgbaComponent::class)
-        subclass(RigidbodyComponent::class)
-        subclass(SizeComponent::class)
-        subclass(SoundComponent::class)
-        subclass(SpawnerComponent::class)
-        subclass(SpriteLayersComponent::class)
-        subclass(SpriteComponent::class)
-        subclass(SubEntitiesComponent::class)
-        subclass(SwitchLayerVisibilityComponent::class)
-        subclass(TextFieldComponent::class)
-        subclass(TiledLevelMapComponent::class)
-        subclass(TweenPropertyComponent::class)
-        subclass(TweenSequenceComponent::class)
-    }
-    // Register tags (components without properties)
-    polymorphic(UniqueId::class) {
-        subclass(RenderLayerTag::class, PolymorphicEnumSerializer( RenderLayerTag.serializer()))
-    }
-
-    // Data class hierarchy used for AnimationScript component
-    polymorphic(TweenBase::class) {
-        subclass(SpawnNewTweenSequence::class)
-        subclass(ParallelTweens::class)
-        subclass(Wait::class)
-        subclass(Jump::class)
-        subclass(SpawnEntity::class)
-        subclass(ExecuteConfigFunction::class)
-        subclass(DeleteEntity::class)
-        subclass(TweenRgba::class)
-        subclass(TweenPosition::class)
-        subclass(TweenMotion::class)
-        subclass(TweenSprite::class)
-        subclass(TweenSwitchLayerVisibility::class)
-        subclass(TweenSpawner::class)
-        subclass(TweenSound::class)
-        subclass(TweenTextField::class)
-        subclass(TweenTouchInput::class)
-    }
-}
-
-/**
  * The JsonSerializer is used to store the world snapshot to persistent storage.
  * All Korge-fleks internal components are already registered as polymorphic subclass
  * in the internal module.
@@ -171,6 +101,9 @@ class SnapshotSerializer {
         modulesMap.remove(name)
     }
 
+    /**
+     * Get the Json serializer with all registered modules for serializing and deserializing entities of the fleks world.
+     */
     fun json(pretty: Boolean = false) : Json {
         if (dirty) {
             var modules = internalModule
@@ -186,6 +119,76 @@ class SnapshotSerializer {
             dirty = false
         }
         return json
+    }
+
+    /**
+     * This polymorphic module config for kotlinx serialization lists all Korge-fleks
+     * internal components as subclasses.
+     */
+    private val internalModule = SerializersModule {
+        // Register data classes
+        polymorphic(CloneableData::class) {
+            subclass(ParallaxComponent.Layer::class)
+            subclass(ParallaxComponent.Plane::class)
+            subclass(RgbaComponent.Rgb::class)
+            subclass(OffsetByFrameIndexComponent.Point::class)
+            subclass(SpriteLayersComponent.LayerProperties::class)
+            subclass(LayeredSpriteComponent.Layer::class)
+        }
+
+        // Register component classes
+        polymorphic(Component::class) {
+            subclass(EntityLinkComponent::class)
+            subclass(InfoComponent::class)
+            subclass(TouchInputComponent::class)
+            subclass(LayerComponent::class)
+            subclass(LayeredSpriteComponent::class)
+            subclass(LayoutComponent::class)
+            subclass(LdtkLevelMapComponent::class)
+            subclass(LifeCycleComponent::class)
+            subclass(MotionComponent::class)
+            subclass(NoisyMoveComponent::class)
+            subclass(OffsetByFrameIndexComponent::class)
+            subclass(ParallaxComponent::class)
+            subclass(PositionComponent::class)
+            subclass(RgbaComponent::class)
+            subclass(RigidbodyComponent::class)
+            subclass(SizeComponent::class)
+            subclass(SoundComponent::class)
+            subclass(SpawnerComponent::class)
+            subclass(SpriteLayersComponent::class)
+            subclass(SpriteComponent::class)
+            subclass(SubEntitiesComponent::class)
+            subclass(SwitchLayerVisibilityComponent::class)
+            subclass(TextFieldComponent::class)
+            subclass(TiledLevelMapComponent::class)
+            subclass(TweenPropertyComponent::class)
+            subclass(TweenSequenceComponent::class)
+        }
+        // Register tags (components without properties)
+        polymorphic(UniqueId::class) {
+            subclass(RenderLayerTag::class, PolymorphicEnumSerializer( RenderLayerTag.serializer()))
+        }
+
+        // Data class hierarchy used for AnimationScript component
+        polymorphic(TweenBase::class) {
+            subclass(SpawnNewTweenSequence::class)
+            subclass(ParallelTweens::class)
+            subclass(Wait::class)
+            subclass(Jump::class)
+            subclass(SpawnEntity::class)
+            subclass(ExecuteConfigFunction::class)
+            subclass(DeleteEntity::class)
+            subclass(TweenRgba::class)
+            subclass(TweenPosition::class)
+            subclass(TweenMotion::class)
+            subclass(TweenSprite::class)
+            subclass(TweenSwitchLayerVisibility::class)
+            subclass(TweenSpawner::class)
+            subclass(TweenSound::class)
+            subclass(TweenTextField::class)
+            subclass(TweenTouchInput::class)
+        }
     }
 }
 

--- a/korge-fleks/src/commonTest/kotlin/korlibs/korge/fleks/components/CommonTestEnv.kt
+++ b/korge-fleks/src/commonTest/kotlin/korlibs/korge/fleks/components/CommonTestEnv.kt
@@ -1,14 +1,9 @@
 package korlibs.korge.fleks.components
 
 import com.github.quillraven.fleks.*
-import korlibs.io.async.*
-import korlibs.io.file.std.*
 import korlibs.korge.fleks.entity.*
-import korlibs.korge.fleks.entity.EntityFactory.EntityConfig
 import korlibs.korge.fleks.utils.*
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
-import kotlin.coroutines.*
 import kotlin.test.assertFalse
 
 

--- a/korge-fleks/src/commonTest/kotlin/korlibs/korge/fleks/components/TweenPropertyComponentTest.kt
+++ b/korge-fleks/src/commonTest/kotlin/korlibs/korge/fleks/components/TweenPropertyComponentTest.kt
@@ -4,7 +4,7 @@ import com.github.quillraven.fleks.*
 import korlibs.korge.fleks.components.RgbaComponent.Rgb
 import korlibs.korge.fleks.components.TweenPropertyComponent.*
 import korlibs.korge.fleks.components.TweenPropertyComponent.TweenProperty.*
-import korlibs.math.interpolation.Easing
+import korlibs.math.interpolation.*
 import kotlin.test.*
 
 internal class TweenPropertyComponentTest {

--- a/korge-fleks/src/commonTest/kotlin/korlibs/korge/fleks/components/TweenSequenceComponentTest.kt
+++ b/korge-fleks/src/commonTest/kotlin/korlibs/korge/fleks/components/TweenSequenceComponentTest.kt
@@ -1,10 +1,9 @@
 package korlibs.korge.fleks.components
 
 import com.github.quillraven.fleks.*
-import korlibs.math.interpolation.Easing
 import korlibs.korge.fleks.entity.EntityFactory
-import korlibs.korge.fleks.entity.EntityFactory.EntityConfig
 import korlibs.korge.fleks.components.TweenSequenceComponent.*
+import korlibs.math.interpolation.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
 


### PR DESCRIPTION
Additional serializer modules can be added now on creation of the GameStateManager. Thus, its code could now finally be moved into Korge-fleks.