### PR TITLE
Add workaround for compiling target android with Korge Forge

### DIFF
--- a/fleks/build.extra.gradle
+++ b/fleks/build.extra.gradle
@@ -1,0 +1,12 @@
+// Fixes "java 21 vs 1.8 problem" if kProject is used with targetJvm() and targetAndroid()
+var javaVersion = 21
+
+kotlin {
+    jvmToolchain(javaVersion)
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(javaVersion))
+    }
+}

--- a/korge-fleks/build.extra.gradle
+++ b/korge-fleks/build.extra.gradle
@@ -1,0 +1,12 @@
+// Fixes "java 21 vs 1.8 problem" if kProject is used with targetJvm() and targetAndroid()
+var javaVersion = 21
+
+kotlin {
+    jvmToolchain(javaVersion)
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(javaVersion))
+    }
+}


### PR DESCRIPTION
This fixes "javaCompiler 21 vs kotlinCompiler 1.8" error in kproject setup with Korge Forge.